### PR TITLE
Correct RPI compilation issues

### DIFF
--- a/makefile
+++ b/makefile
@@ -15,7 +15,7 @@ C = rtl_airband.cpp hello_fft/mailbox.c hello_fft/gpu_fft.c hello_fft/gpu_fft_tw
 
 B = rtl_airband
 
-F = -fpermissive -O3 -mcpu=arm1176jzf-s -mtune=arm1176jzf-s -march=armv6zk -mfpu=vfp -lrt -lm -lvorbisenc -lmp3lame -lshout -lpthread -lrtlsdr -o $(B)
+F = -O3 -mcpu=arm1176jzf-s -mtune=arm1176jzf-s -march=armv6zk -mfpu=vfp -lrt -lm -lvorbisenc -lmp3lame -lshout -lpthread -lrtlsdr -o $(B)
 
 $(B):	$(H) $(C) $(S)
 	as -o rtl_airband_asm.o $(S)

--- a/rtl_airband.cpp
+++ b/rtl_airband.cpp
@@ -175,7 +175,7 @@ void* rtlsdr_exec(void* params) {
     if (NULL == dev) {
         fprintf(stderr, "Failed to open rtlsdr device #%d.\n", dev->device);
         error();
-        return;
+        return NULL;
     }
     rtlsdr_set_sample_rate(dev->rtlsdr, SOURCE_RATE);
     rtlsdr_set_center_freq(dev->rtlsdr, dev->centerfreq);


### PR DESCRIPTION
Correct void\* error on RPI at compil time.
Add missing file to compil for fft GPU RPI.

As suggested by https://github.com/microtony/RTLSDR-Airband/issues/4
